### PR TITLE
Fix clipboard on Android native app (#21)

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -24,9 +24,11 @@ export async function copyToClipboard(text) {
   // Check if running in Capacitor (mobile app)
   if (window.Capacitor) {
     try {
-      const { Clipboard } = await import("@capacitor/clipboard");
-      await Clipboard.write({ string: text });
-      return;
+      const { Clipboard } = window.Capacitor.Plugins;
+      if (Clipboard) {
+        await Clipboard.write({ string: text });
+        return;
+      }
     } catch (error) {
       // If Capacitor clipboard fails, fall back to web API
       console.warn("Native clipboard failed, falling back to web API:", error);
@@ -48,14 +50,16 @@ export async function shareContent(title, text, url) {
   // Check if running in Capacitor (mobile app)
   if (window.Capacitor) {
     try {
-      const { Share } = await import("@capacitor/share");
-      await Share.share({
-        title: title,
-        text: text,
-        url: url,
-        dialogTitle: title,
-      });
-      return;
+      const { Share } = window.Capacitor.Plugins;
+      if (Share) {
+        await Share.share({
+          title: title,
+          text: text,
+          url: url,
+          dialogTitle: title,
+        });
+        return;
+      }
     } catch (error) {
       // If native share fails or is cancelled, fail silently
       console.warn("Native share failed or was cancelled:", error);


### PR DESCRIPTION
## Summary

Fixes #21 - clipboard doesn't work on native app

This PR fixes the clipboard and share functionality on the Android native app by replacing problematic ES module dynamic imports with direct Capacitor plugin access.

## Root Cause

The clipboard functionality was failing because the code was attempting to use dynamic ES module imports to access Capacitor plugins:

```javascript
const { Clipboard } = await import("@capacitor/clipboard");
```

In a Capacitor Android app, NPM packages aren't bundled or available at runtime. Instead, Capacitor plugins are exposed via the global `window.Capacitor.Plugins` object injected by the native bridge.

## Changes

- **copyToClipboard function**: Use `window.Capacitor.Plugins.Clipboard` instead of importing `@capacitor/clipboard`
- **shareContent function**: Use `window.Capacitor.Plugins.Share` instead of importing `@capacitor/share`
- Added null checks for plugin availability before use
- Maintained same fallback logic and error handling

This aligns with the pattern already used in `deeplink.js` for accessing the App plugin.

## Test Plan

- [ ] Build and deploy Android APK with this fix
- [ ] Test copying admin link on Android app
- [ ] Test copying participant links on Android app
- [ ] Test sharing admin link on Android app
- [ ] Test sharing participant links on Android app
- [ ] Verify error messages are translated properly if fallbacks fail
- [ ] Verify web version still works (should use web API fallback)

## Validation

All code quality checks pass:
- ✅ `npm run lint` - 0 warnings, 0 errors
- ✅ `npm run format` - All files correctly formatted
- ✅ `npm run validate:i18n` - All locale files valid