### PR TITLE
fix: resolve deep link race condition on Android app startup (#23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,22 +8,46 @@ Open Secret Santa is a client-side Secret Santa gift exchange organizer with no 
 
 ## Development Commands
 
+**IMPORTANT**: Always use `mise` tasks for development operations. Do not use direct `npm` or `node` commands unless absolutely necessary.
+
+### Available Mise Tasks
+
+- **`mise run dev`** - Start local development server
+- **`mise run test`** - Start server and open application in browser
+- **`mise run lint`** - Run ESLint on JavaScript files
+- **`mise run format`** - Check code formatting with Prettier
+- **`mise run format-fix`** - Fix code formatting with Prettier
+- **`mise run validate-i18n`** - Validate i18n JSON files against schema
+- **`mise run validate-all`** - Run all validation checks (lint + format + i18n)
+
 ### Starting the Development Server
 
-Using mise (recommended):
 ```bash
 mise run dev
-```
-
-Or manually:
-```bash
-python -m http.server 8000
-# Then visit http://localhost:8000
 ```
 
 ### Testing
 ```bash
 mise run test  # Starts server and opens browser
+```
+
+### Code Quality
+
+**Before committing**, ALWAYS run validation tasks:
+
+```bash
+# Run all validations (required before commit)
+mise run validate-all
+
+# Or run individually:
+mise run lint          # Check for code issues
+mise run format        # Check formatting
+mise run validate-i18n # Validate translations
+```
+
+**To auto-fix formatting issues:**
+```bash
+mise run format-fix
 ```
 
 ## Code Architecture

--- a/js/deeplink.js
+++ b/js/deeplink.js
@@ -3,16 +3,21 @@
  * Handles incoming URLs when the app is opened via deep links
  */
 
+// Track deep link state
+let deepLinkPromise = null;
+let deepLinkResolver = null;
+
 /**
  * Initialize deep link listener
  * Sets up event listener for Capacitor appUrlOpen events
  * @param {Function} onDeepLink - Callback function to handle deep link with params object
+ * @returns {Promise|null} Promise that resolves when deep link is processed, or null if not available
  */
 export function initDeepLinking(onDeepLink) {
   // Check if Capacitor App plugin is available (mobile environment)
   if (typeof window.Capacitor === "undefined") {
     console.log("Capacitor not available - deep linking disabled");
-    return;
+    return null;
   }
 
   // Get the App plugin from Capacitor
@@ -20,38 +25,55 @@ export function initDeepLinking(onDeepLink) {
 
   if (!App) {
     console.log("Capacitor App plugin not available");
-    return;
+    return null;
   }
 
-  // Listen for app URL open events
-  App.addListener("appUrlOpen", (event) => {
-    console.log("Deep link received:", event.url);
+  // Create a promise that resolves when a deep link is received or times out
+  deepLinkPromise = new Promise((resolve) => {
+    deepLinkResolver = resolve;
 
-    try {
-      // Parse the URL to extract query parameters
-      const url = new URL(event.url);
-      const params = {
-        data: url.searchParams.get("data"),
-        admin: url.searchParams.get("admin"),
-        user: url.searchParams.get("user")
-          ? decodeURIComponent(url.searchParams.get("user"))
-          : null,
-      };
+    // Listen for app URL open events
+    App.addListener("appUrlOpen", (event) => {
+      console.log("Deep link received:", event.url);
 
-      // Validate that we have the required data parameter
-      if (!params.data) {
-        console.warn("Deep link missing data parameter:", event.url);
-        return;
+      try {
+        // Parse the URL to extract query parameters
+        const url = new URL(event.url);
+        const params = {
+          data: url.searchParams.get("data"),
+          admin: url.searchParams.get("admin"),
+          user: url.searchParams.get("user")
+            ? decodeURIComponent(url.searchParams.get("user"))
+            : null,
+        };
+
+        // Validate that we have the required data parameter
+        if (!params.data) {
+          console.warn("Deep link missing data parameter:", event.url);
+          resolve({ handled: false });
+          return;
+        }
+
+        // Call the callback with the parsed parameters
+        onDeepLink(params);
+
+        // Signal that deep link was handled
+        resolve({ handled: true });
+      } catch (error) {
+        console.error("Error processing deep link:", error);
+        resolve({ handled: false });
       }
+    });
 
-      // Call the callback with the parsed parameters
-      onDeepLink(params);
-    } catch (error) {
-      console.error("Error processing deep link:", error);
-    }
+    // Timeout after 100ms if no deep link is received
+    // This allows the app to proceed with normal routing
+    setTimeout(() => {
+      resolve({ handled: false, timeout: true });
+    }, 100);
   });
 
   console.log("Deep linking initialized");
+  return deepLinkPromise;
 }
 
 /**

--- a/js/deeplink.js
+++ b/js/deeplink.js
@@ -5,7 +5,6 @@
 
 // Track deep link state
 let deepLinkPromise = null;
-let deepLinkResolver = null;
 
 /**
  * Initialize deep link listener
@@ -30,7 +29,6 @@ export function initDeepLinking(onDeepLink) {
 
   // Create a promise that resolves when a deep link is received or times out
   deepLinkPromise = new Promise((resolve) => {
-    deepLinkResolver = resolve;
 
     // Listen for app URL open events
     App.addListener("appUrlOpen", (event) => {

--- a/js/deeplink.js
+++ b/js/deeplink.js
@@ -29,7 +29,6 @@ export function initDeepLinking(onDeepLink) {
 
   // Create a promise that resolves when a deep link is received or times out
   deepLinkPromise = new Promise((resolve) => {
-
     // Listen for app URL open events
     App.addListener("appUrlOpen", (event) => {
       console.log("Deep link received:", event.url);

--- a/js/main.js
+++ b/js/main.js
@@ -200,6 +200,20 @@ function updatePageText() {
  * Initialize the application
  */
 async function init() {
+  // Initialize deep linking FIRST for Android App Links
+  // This must happen before i18n to prevent language detection from interfering
+  const deepLinkPromise = initDeepLinking((params) => {
+    // Handle deep link navigation when app is opened via URL
+    handleDeepLinkNavigation(
+      params,
+      setupViewMode,
+      showPage,
+      showError,
+      goToLanding,
+      () => t("validation.invalidUrl"),
+    );
+  });
+
   // Initialize i18n system
   await initI18n();
 
@@ -217,19 +231,6 @@ async function init() {
   // Listen for language changes
   window.addEventListener("languagechange", () => {
     updatePageText();
-  });
-
-  // Initialize deep linking for Android App Links
-  const deepLinkPromise = initDeepLinking((params) => {
-    // Handle deep link navigation when app is opened via URL
-    handleDeepLinkNavigation(
-      params,
-      setupViewMode,
-      showPage,
-      showError,
-      goToLanding,
-      () => t("validation.invalidUrl"),
-    );
   });
 
   // Wait for potential deep link before proceeding with normal routing

--- a/js/main.js
+++ b/js/main.js
@@ -200,18 +200,14 @@ function updatePageText() {
  * Initialize the application
  */
 async function init() {
+  // Store deep link params if received before i18n is ready
+  let pendingDeepLinkParams = null;
+
   // Initialize deep linking FIRST for Android App Links
   // This must happen before i18n to prevent language detection from interfering
   const deepLinkPromise = initDeepLinking((params) => {
-    // Handle deep link navigation when app is opened via URL
-    handleDeepLinkNavigation(
-      params,
-      setupViewMode,
-      showPage,
-      showError,
-      goToLanding,
-      () => t("validation.invalidUrl"),
-    );
+    console.log("Deep link callback triggered with params:", params);
+    pendingDeepLinkParams = params;
   });
 
   // Initialize i18n system
@@ -238,8 +234,20 @@ async function init() {
   if (deepLinkPromise) {
     const deepLinkResult = await deepLinkPromise;
 
-    // If deep link was handled, stop here and let the deep link handler do the routing
-    if (deepLinkResult.handled) {
+    // If deep link was handled, process it now that i18n is ready
+    if (deepLinkResult.handled && pendingDeepLinkParams) {
+      console.log("Processing deep link with params:", pendingDeepLinkParams);
+
+      // Handle deep link navigation now that all dependencies are ready
+      handleDeepLinkNavigation(
+        pendingDeepLinkParams,
+        setupViewMode,
+        showPage,
+        showError,
+        goToLanding,
+        () => t("validation.invalidUrl"),
+      );
+
       console.log("Deep link handled, skipping normal routing");
       return;
     }


### PR DESCRIPTION
## Summary

Fixes #23 - Opening a Secret Santa link on the native Android app now works correctly and navigates to the proper subpage instead of showing the landing page.

## Problem

When the Android app was opened via a deep link (e.g., `https://secret-santa.bombfork.net/?data=...&user=Alice`), the app would show the landing page instead of the participant or admin view.

### Root Cause

Race condition in the initialization flow:
1. `initDeepLinking()` set up an event listener for `appUrlOpen` events
2. Immediately after, `parseUrlParams()` checked `window.location.search`
3. When opened via deep link, `window.location.search` was empty because the URL parameters were in the pending deep link event, not in `window.location`
4. App showed the landing page
5. Deep link event fired too late, attempting to route again

## Solution

Implemented a Promise-based approach that waits for potential deep link events before proceeding with normal routing:

### Changes

**js/deeplink.js**:
- Added module-level state tracking for deep link promise
- Modified `initDeepLinking()` to return a Promise that resolves when:
  - A deep link is received and handled (`{ handled: true }`)
  - A deep link is received but invalid (`{ handled: false }`)
  - 100ms timeout elapses with no deep link (`{ handled: false, timeout: true }`)
- Returns `null` if Capacitor is not available (web environment)

**js/main.js**:
- Capture the Promise returned by `initDeepLinking()`
- Await the Promise before proceeding with normal routing
- If deep link was handled, skip normal routing and return
- If no deep link or timeout, proceed with normal routing
- Web version unaffected (no waiting, immediate routing)

**DEEP_LINKING.md**:
- Updated "Code Flow" section to document the new Promise-based approach
- Added explanation of race condition prevention mechanism

## How It Works

**On Android (deep link opened):**
1. App starts, sets up deep link listener with Promise
2. Waits up to 100ms for deep link event
3. Deep link event fires (typically within a few milliseconds)
4. Routes to correct view via deep link handler
5. Promise resolves with `{ handled: true }`
6. Main initialization skips normal routing
7. User sees the correct view ✅

**On Android (direct app open):**
1. App starts, sets up deep link listener with Promise
2. Waits 100ms for deep link event
3. No event fires, timeout occurs
4. Promise resolves with `{ handled: false, timeout: true }`
5. Normal routing proceeds using `window.location`
6. Landing page shown ✅

**On Web (browser):**
1. `initDeepLinking()` returns `null` (no Capacitor)
2. No waiting occurs
3. Normal routing proceeds immediately
4. No performance impact ✅

## Testing

**Manual Testing Required:**
```bash
# Install the app on Android device/emulator
npm run cap:sync
npm run cap:run:android

# Use the test script to test deep links
./scripts/test-deep-link.sh

# Test with specific URLs:
# Participant URL
./scripts/test-deep-link.sh 'https://secret-santa.bombfork.net/?data=...&user=Alice'

# Admin URL
./scripts/test-deep-link.sh 'https://secret-santa.bombfork.net/?data=...&admin=true'
```

**Expected Behavior:**
- ✅ Deep links open in app and show correct view
- ✅ Direct app launch shows landing page
- ✅ Web version continues to work normally
- ✅ No performance degradation

**Verification:**
- All JavaScript syntax validated
- Documentation updated
- No breaking changes to existing functionality

## Benefits

1. **Fixes the race condition**: Deep link routing happens before normal routing
2. **Minimal delay**: 100ms timeout is brief and only affects Android app
3. **No web impact**: Web version sees no delay (returns null immediately)
4. **Graceful fallback**: If deep link fails, normal routing still works
5. **Backward compatible**: No breaking changes to existing code
6. **Clear logging**: Console logs help debug any issues

## Test Plan

- [ ] Build and install Android APK
- [ ] Click participant link → Opens in app showing participant view
- [ ] Click admin link → Opens in app showing admin password prompt
- [ ] Launch app directly → Shows landing page
- [ ] Test web version → Works normally with no delay
- [ ] Check browser console for proper logging